### PR TITLE
Add SST and turbidity features with Feast config

### DIFF
--- a/features/feature_repo.yaml
+++ b/features/feature_repo.yaml
@@ -1,0 +1,11 @@
+project: reefguard
+registry: s3://reefguard/registry.db
+provider: local
+
+online_store:
+  type: redis
+  connection_string: redis://localhost:6379/0
+
+offline_store:
+  type: file
+  path: s3://reefguard/features

--- a/features/sst_features.py
+++ b/features/sst_features.py
@@ -1,0 +1,31 @@
+from datetime import timedelta
+
+from feast import Entity, FeatureView, Field, FileSource
+from feast.types import Float32
+from feast.file_format import ParquetFormat
+
+# Entity representing a reef location
+reef_id = Entity(name="reef_id", join_keys=["reef_id"])
+
+# Offline data source stored as Parquet files on S3
+sst_turbidity_source = FileSource(
+    name="sst_turbidity_source",
+    path="s3://reefguard/features/sst_turbidity.parquet",
+    timestamp_field="event_timestamp",
+    created_timestamp_column="created",
+    file_format=ParquetFormat(),
+)
+
+# Feature view exposing sea surface temperature and turbidity features
+sst_turbidity_view = FeatureView(
+    name="sst_turbidity_view",
+    entities=[reef_id],
+    ttl=timedelta(hours=24),
+    schema=[
+        Field(name="sst_celsius", dtype=Float32),
+        Field(name="turbidity_ntu", dtype=Float32),
+    ],
+    online=True,
+    source=sst_turbidity_source,
+    tags={"team": "reefguard"},
+)


### PR DESCRIPTION
## Summary
- Configure Feast repo with Redis online store and S3-based Parquet offline store
- Define `sst_turbidity_view` FeatureView exposing SST and turbidity features

## Testing
- `pytest -q`