### PR TITLE
Add MLflow deployment and model approval policy

### DIFF
--- a/.github/workflows/model-approval.yml
+++ b/.github/workflows/model-approval.yml
@@ -1,0 +1,20 @@
+name: model-approval
+on:
+  pull_request:
+    paths:
+      - 'models/**'
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install mlflow
+      - name: Verify approved models
+        env:
+          MLFLOW_TRACKING_URI: ${{ secrets.MLFLOW_TRACKING_URI }}
+        run: python scripts/check_model_approval.py

--- a/helm/mlflow/README.md
+++ b/helm/mlflow/README.md
@@ -1,0 +1,10 @@
+# MLflow Helm Deployment
+
+This chart values file configures an MLflow tracking server with a SQLite backend and S3 artifact store. Deploy using the official MLflow chart:
+
+```bash
+helm repo add mlflow https://mlflow.github.io/mlflow-helm
+helm upgrade --install mlflow mlflow/mlflow -f values.yaml
+```
+
+Set `MLFLOW_TRACKING_URI` to the service URL for the training code.

--- a/helm/mlflow/values.yaml
+++ b/helm/mlflow/values.yaml
@@ -1,0 +1,12 @@
+---
+tracking:
+  defaultArtifactRoot: s3://reefguard-mlflow
+backendStore:
+  database:
+    type: sqlite
+    path: /mlflow/mlflow.db
+service:
+  type: ClusterIP
+  port: 5000
+ingress:
+  enabled: false

--- a/models/approved_models.txt
+++ b/models/approved_models.txt
@@ -1,0 +1,1 @@
+reefguard-model

--- a/models/trainer/train.py
+++ b/models/trainer/train.py
@@ -1,0 +1,44 @@
+import argparse
+import os
+
+import mlflow
+import mlflow.sklearn
+from sklearn.datasets import load_iris
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import accuracy_score
+from sklearn.model_selection import train_test_split
+
+
+DEFAULT_MODEL_NAME = "reefguard-model"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Train a simple model and register with MLflow")
+    parser.add_argument("--experiment", default="reefguard", help="MLflow experiment name")
+    parser.add_argument("--model-name", default=DEFAULT_MODEL_NAME, help="Registered model name")
+    return parser.parse_args()
+
+
+def train(args: argparse.Namespace) -> None:
+    data = load_iris()
+    x_train, x_test, y_train, y_test = train_test_split(
+        data.data, data.target, test_size=0.2, random_state=42
+    )
+
+    with mlflow.start_run():
+        clf = LogisticRegression(max_iter=200)
+        clf.fit(x_train, y_train)
+        preds = clf.predict(x_test)
+        acc = accuracy_score(y_test, preds)
+        mlflow.log_metric("accuracy", float(acc))
+        mlflow.sklearn.log_model(clf, artifact_path="model")
+        model_uri = mlflow.get_artifact_uri("model")
+        result = mlflow.register_model(model_uri, args.model_name)
+        print(f"Registered model {result.name} version {result.version}")
+
+
+if __name__ == "__main__":
+    mlflow.set_tracking_uri(os.getenv("MLFLOW_TRACKING_URI", "http://localhost:5000"))
+    cli_args = parse_args()
+    mlflow.set_experiment(cli_args.experiment)
+    train(cli_args)

--- a/scripts/check_model_approval.py
+++ b/scripts/check_model_approval.py
@@ -1,0 +1,30 @@
+import os
+from pathlib import Path
+
+import mlflow
+
+
+APPROVED_FILE = Path("models/approved_models.txt")
+
+
+def main() -> None:
+    tracking_uri = os.getenv("MLFLOW_TRACKING_URI", "http://localhost:5000")
+    mlflow.set_tracking_uri(tracking_uri)
+
+    approved = {
+        line.strip() for line in APPROVED_FILE.read_text().splitlines() if line.strip()
+    }
+    client = mlflow.MlflowClient()
+
+    for rm in client.list_registered_models():
+        name = rm.name
+        latest = client.get_latest_versions(name)
+        for mv in latest:
+            if mv.current_stage in {"Staging", "Production"} and name not in approved:
+                msg = f"Model {name} in stage {mv.current_stage} is not approved"
+                raise SystemExit(msg)
+    print("All models in staging or production are approved")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- deploy MLflow using Helm values
- register models in training script
- enforce approved model promotion via GitHub Action

## Testing
- `python -m py_compile models/trainer/train.py scripts/check_model_approval.py`
- `yamllint helm/mlflow/values.yaml`
- `pytest -q`