### PR TITLE
docs: expand README and add demo script

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,29 +3,50 @@
 ## Table of Contents
 
 1. [Project Overview](#project-overview)
-2. [End‑to‑End Workflow Diagram](#end-to-end-workflow-diagram)
-3. [Core Competencies & How They’re Demonstrated](#core-competencies--how-theyre-demonstrated)
-4. [Tech Stack](#tech-stack)
-5. [Data Sources](#data-sources)
-6. [Repository Structure](#repository-structure)
-7. [Local Development Quick‑Start](#local-development-quick-start)
-8. [Infrastructure‑as‑Code](#infrastructure-as-code)
-9. [Data & Feature Management](#data--feature-management)
-10. [Automated Training & Tuning](#automated-training--tuning)
-11. [Model Registry & Promotion Workflow](#model-registry--promotion-workflow)
-12. [CI/CD Pipelines](#cicd-pipelines)
-13. [Model Serving & Deployment Strategies](#model-serving--deployment-strategies)
-14. [Monitoring & Observability](#monitoring--observability)
-15. [Cost Optimisation](#cost-optimisation)
-16. [Troubleshooting & FAQ](#troubleshooting--faq)
-17. [Stretch Goals](#stretch-goals)
-18. [References](#references)
+2. [Prerequisites](#prerequisites)
+3. [End‑to‑End Workflow Diagram](#end-to-end-workflow-diagram)
+4. [Core Competencies & How They’re Demonstrated](#core-competencies--how-theyre-demonstrated)
+5. [Tech Stack](#tech-stack)
+6. [Data Sources](#data-sources)
+7. [Repository Structure](#repository-structure)
+8. [Local Development Quick‑Start](#local-development-quick-start)
+9. [Example Commands](#example-commands)
+10. [Infrastructure‑as‑Code](#infrastructure-as-code)
+11. [Data & Feature Management](#data--feature-management)
+12. [Automated Training & Tuning](#automated-training--tuning)
+13. [Model Registry & Promotion Workflow](#model-registry--promotion-workflow)
+14. [CI/CD Pipelines](#cicd-pipelines)
+15. [Model Serving & Deployment Strategies](#model-serving--deployment-strategies)
+16. [Monitoring & Observability](#monitoring--observability)
+17. [Cost Optimisation](#cost-optimisation)
+18. [Troubleshooting & FAQ](#troubleshooting--faq)
+19. [Stretch Goals](#stretch-goals)
+20. [References](#references)
 
 ---
 
 ## Project Overview
 
 **ReefGuard AI** is a fully‑automated MLOps platform that predicts coral‑bleaching risk for the Great Barrier Reef by ingesting live MODIS/Sentinel‑2 sea‑surface‑temperature imagery and Queensland buoy sensor streams, materialising features in Feast, training an XGBoost + Vision Transformer ensemble via Kubeflow Pipelines and Katib tuning, registering models in MLflow with GitHub‑gated promotion, and rolling canary deployments to KFServing (or AWS SageMaker Serverless GPU) with Istio traffic splitting.  Evidently AI monitors data & prediction drift, triggering auto‑re‑training jobs and Slack alerts.  All infra is codified with Terraform and Helm; CI/CD runs through GitHub Actions.  Idle cost ≈ AUD 20/month.
+
+**Key capabilities**
+
+- Near‑real‑time ingestion of satellite and buoy observations.
+- Feature materialisation and online serving via Feast.
+- Automated training and hyper‑parameter tuning with Kubeflow Pipelines and Katib.
+- Experiment tracking and model registry powered by MLflow.
+- Canary or serverless GPU deployment through KFServing or SageMaker.
+- Continuous drift monitoring with Evidently AI and automated retraining triggers.
+
+## Prerequisites
+
+The project assumes the following tools are installed locally:
+
+- [Python 3.10+](https://www.python.org/)
+- [Docker](https://www.docker.com/) and [Docker Compose](https://docs.docker.com/compose/)
+- [kubectl](https://kubernetes.io/docs/tasks/tools/) and [Helm](https://helm.sh/) for interacting with Kubernetes clusters
+- [Terraform](https://www.terraform.io/) for infrastructure provisioning
+- Optional: [conda](https://docs.conda.io/) for environment management
 
 ---
 
@@ -153,6 +174,22 @@ feast apply
 # Run a tiny sample pipeline
 python pipelines/kfp_v2/etl_pipeline.py --local-sample
 python models/trainer/train.py --sample-data
+```
+
+## Example Commands
+
+```bash
+# Run tests
+pytest -q
+
+# Build training image
+docker build -t reefguard/trainer models/trainer
+
+# Trigger a sample training run
+python models/trainer/train.py --sample-data
+
+# Serve the latest model locally
+python models/inference/app.py --model-path models/artifacts/latest
 ```
 
 ---

--- a/docs/demo_script.md
+++ b/docs/demo_script.md
@@ -1,0 +1,37 @@
+# ReefGuard AI Demo Script
+
+This walkthrough demonstrates an end-to-end run of the ReefGuard AI pipeline on a developer workstation.
+
+1. **Clone and install**
+   ```bash
+   git clone https://github.com/example/Australian_ReefGuard-AI.git
+   cd Australian_ReefGuard-AI
+   conda create -n reefguard python=3.11 -y && conda activate reefguard
+   pip install -r requirements-dev.txt
+   ```
+2. **Launch local services** – start MLflow for experiment tracking and apply Feast feature definitions.
+   ```bash
+   mlflow server --backend-store-uri sqlite:///mlflow.db --default-artifact-root ./mlruns &
+   feast apply
+   ```
+3. **Ingest sample data** – run a lightweight ETL pipeline to pull a small dataset.
+   ```bash
+   python pipelines/kfp_v2/etl_pipeline.py --local-sample
+   ```
+4. **Train a model** – execute the training script on the sample data.
+   ```bash
+   python models/trainer/train.py --sample-data
+   ```
+5. **Serve the model** – launch a simple inference service.
+   ```bash
+   python models/inference/app.py --model-path models/artifacts/latest
+   ```
+6. **Query the endpoint** – send a test request and review the prediction.
+   ```bash
+   curl -X POST -H "Content-Type: application/json" \
+        -d '{"features": {"sst": 28.4, "turbidity": 3.1}}' \
+        http://localhost:8000/predict
+   ```
+7. **Clean up** – stop background services and remove temporary files.
+
+These steps can be adapted for live infrastructure by swapping the local commands for their Kubernetes or Terraform equivalents.


### PR DESCRIPTION
## Summary
- document key capabilities and prerequisites in README
- add example commands for running tests, building image, and serving a model
- provide end-to-end demo walkthrough

## Testing
- `pytest -q`