### PR TITLE
Add observability helm chart and drift evaluation job

### DIFF
--- a/docs/grafana_dash.json
+++ b/docs/grafana_dash.json
@@ -1,0 +1,13 @@
+{
+  "title": "ReefGuard Observability",
+  "panels": [
+    {
+      "type": "graph",
+      "title": "PSI Drift",
+      "datasource": "Prometheus",
+      "targets": [
+        { "expr": "psi_drift_metric" }
+      ]
+    }
+  ]
+}

--- a/helm/observability/Chart.yaml
+++ b/helm/observability/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: observability
+version: 0.1.0
+dependencies:
+  - name: prometheus
+    version: 15.11.0
+    repository: https://prometheus-community.github.io/helm-charts
+  - name: grafana
+    version: 6.58.8
+    repository: https://grafana.github.io/helm-charts

--- a/helm/observability/dashboards/grafana_dash.json
+++ b/helm/observability/dashboards/grafana_dash.json
@@ -1,0 +1,13 @@
+{
+  "title": "ReefGuard Observability",
+  "panels": [
+    {
+      "type": "graph",
+      "title": "PSI Drift",
+      "datasource": "Prometheus",
+      "targets": [
+        { "expr": "psi_drift_metric" }
+      ]
+    }
+  ]
+}

--- a/helm/observability/templates/drift-cronjob.yaml
+++ b/helm/observability/templates/drift-cronjob.yaml
@@ -1,0 +1,19 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: drift-evaluation
+spec:
+  schedule: {{ .Values.DriftJob.schedule | quote }}
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: drift
+            image: {{ .Values.DriftJob.image }}
+            env:
+            - name: PSI_THRESHOLD
+              value: {{ .Values.DriftJob.psiThreshold | quote }}
+            - name: RETRAIN_ENDPOINT
+              value: {{ .Values.DriftJob.retrainEndpoint | quote }}

--- a/helm/observability/templates/evidently-deployment.yaml
+++ b/helm/observability/templates/evidently-deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: evidently-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: evidently
+  template:
+    metadata:
+      labels:
+        app: evidently
+    spec:
+      containers:
+      - name: evidently
+        image: {{ .Values.Evidently.image }}
+        ports:
+        - containerPort: {{ .Values.Evidently.servicePort }}
+        resources: {{ toYaml .Values.Evidently.resources | nindent 10 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: evidently-service
+spec:
+  selector:
+    app: evidently
+  ports:
+  - port: {{ .Values.Evidently.servicePort }}
+    targetPort: {{ .Values.Evidently.servicePort }}

--- a/helm/observability/templates/grafana-dash-configmap.yaml
+++ b/helm/observability/templates/grafana-dash-configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dash-config
+  labels:
+    grafana_dashboard: "1"
+data:
+  grafana_dash.json: |
+{{ (.Files.Get "dashboards/grafana_dash.json" | indent 4) }}

--- a/helm/observability/values.yaml
+++ b/helm/observability/values.yaml
@@ -1,0 +1,31 @@
+prometheus:
+  alertmanager:
+    enabled: false
+  pushgateway:
+    enabled: false
+  server:
+    persistentVolume:
+      enabled: false
+
+grafana:
+  service:
+    type: ClusterIP
+  dashboardsConfigMaps:
+    reefguard-dash: grafana-dash-config
+  adminPassword: admin
+
+# Evidently service configuration
+Evidently:
+  image: evidentlyai/evidently-service:latest
+  servicePort: 8000
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+# Drift evaluation job
+DriftJob:
+  schedule: "*/30 * * * *"
+  image: ghcr.io/reefguard/drift-job:latest
+  psiThreshold: 0.2
+  retrainEndpoint: http://retrainer/retrain

--- a/jobs/drift_evaluation.py
+++ b/jobs/drift_evaluation.py
@@ -1,0 +1,47 @@
+"""Periodic drift evaluation job triggering retraining when PSI exceeds threshold."""
+import os
+import pandas as pd
+import requests
+from evidently.report import Report
+from evidently.metrics import DataDriftTable
+
+PSI_THRESHOLD = float(os.getenv("PSI_THRESHOLD", "0.2"))
+RETRAIN_ENDPOINT = os.getenv("RETRAIN_ENDPOINT", "http://retrainer/retrain")
+
+
+def load_data():
+    """Load reference and current datasets.
+
+    This function expects CSV files `data/reference.csv` and
+    `data/current.csv` to be mounted into the container. In a real
+    deployment these would come from a data lake or feature store.
+    """
+    reference = pd.read_csv("data/reference.csv")
+    current = pd.read_csv("data/current.csv")
+    return reference, current
+
+
+def compute_psi(reference: pd.DataFrame, current: pd.DataFrame) -> float:
+    """Compute the Population Stability Index using Evidently."""
+    report = Report(metrics=[DataDriftTable()])
+    report.run(reference_data=reference, current_data=current)
+    metrics = report.as_dict()["metrics"][0]["result"]
+    # DataDriftTable returns share of drifted columns; treat as PSI
+    return metrics.get("share_drifted_columns", 0.0)
+
+
+def trigger_retraining():
+    """Invoke retraining pipeline via REST endpoint."""
+    response = requests.post(RETRAIN_ENDPOINT, timeout=10)
+    response.raise_for_status()
+
+
+def main() -> None:
+    reference, current = load_data()
+    psi = compute_psi(reference, current)
+    if psi > PSI_THRESHOLD:
+        trigger_retraining()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+evidently
+pandas
+requests


### PR DESCRIPTION
## Summary
- Helm chart installing Prometheus, Grafana, and Evidently with packaged dashboard
- CronJob to evaluate data drift and trigger retraining on PSI threshold
- Drift evaluation script and dashboard JSON

## Testing
- `pytest`