### PR TITLE
Add CI workflows for model testing and infrastructure planning

### DIFF
--- a/.github/workflows/infra-plan.yml
+++ b/.github/workflows/infra-plan.yml
@@ -1,0 +1,35 @@
+name: infra-plan
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+    paths:
+      - 'infra/**'
+      - '.github/workflows/infra-plan.yml'
+
+jobs:
+  terraform:
+    runs-on: ubuntu-latest
+    env:
+      TF_IN_AUTOMATION: true
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 1.5.0
+      - name: Terraform Init
+        run: terraform init
+      - name: Terraform Plan
+        run: terraform plan -out=tfplan
+      - name: Setup Infracost
+        uses: infracost/actions/setup@v2
+      - name: Cost estimation
+        run: infracost breakdown --path . --format table
+        env:
+          INFRACOST_API_KEY: ${{ secrets.INFRACOST_API_KEY }}
+      - name: Terraform Apply
+        if: github.ref == 'refs/heads/main'
+        run: terraform apply -auto-approve tfplan

--- a/.github/workflows/model-ci.yml
+++ b/.github/workflows/model-ci.yml
@@ -1,0 +1,35 @@
+name: model-ci
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install pytest evidently
+      - name: Run pytest
+        run: pytest
+      - name: Run Evidently tests
+        run: evidently test run
+  docker-build:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Build Docker image
+        run: docker build -t reefguard-ai .


### PR DESCRIPTION
## Summary
- add model CI workflow running pytest, Evidently tests, and Docker build
- add infrastructure workflow executing terraform plan with cost estimation and apply

## Testing
- `pytest`
