### PR TITLE
Add KFServing predictor and deployment assets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+# Simple Dockerfile for KFServing Predictor
+FROM python:3.9-slim
+
+WORKDIR /app
+
+# Copy predictor implementation
+COPY models/inference/predictor.py predictor.py
+
+# Install required dependencies
+RUN pip install --no-cache-dir kserve
+
+# Run the predictor with KFServing ModelServer
+CMD ["python", "predictor.py"]

--- a/models/inference/predictor.py
+++ b/models/inference/predictor.py
@@ -1,0 +1,49 @@
+"""Predictor implementation for KFServing."""
+
+from typing import Dict, List
+
+import kserve
+
+
+class Predictor(kserve.KFModel):
+    """Simple example predictor for KFServing.
+
+    The model echoes the input instances as predictions. In a real scenario,
+    you would load a trained model in :meth:`load` and generate predictions in
+    :meth:`predict`.
+    """
+
+    def __init__(self, name: str, model_dir: str | None = None):
+        super().__init__(name)
+        self.model_dir = model_dir
+        self.ready = False
+
+    def load(self) -> None:
+        """Load model artifacts and mark the model as ready."""
+        # Placeholder for model loading logic.
+        self.ready = True
+
+    def predict(self, request: Dict) -> Dict[str, List]:
+        """Generate predictions from the request payload.
+
+        Parameters
+        ----------
+        request:
+            The request payload passed by KFServing. This implementation
+            expects a JSON object with an ``instances`` field containing a
+            list of inputs.
+
+        Returns
+        -------
+        Dict[str, List]
+            A dictionary with a ``predictions`` key echoing the provided
+            ``instances``.
+        """
+        instances = request.get("instances", [])
+        return {"predictions": instances}
+
+
+if __name__ == "__main__":
+    model = Predictor("reefguard-model")
+    model.load()
+    kserve.ModelServer().start([model])

--- a/serving/inference_service.yaml
+++ b/serving/inference_service.yaml
@@ -1,0 +1,22 @@
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  name: reefguard-predictor
+  annotations:
+    networking.kserve.io/target-stable-revision: reefguard-predictor-predictor-default
+    networking.kserve.io/target-canary-revision: reefguard-predictor-predictor-canary
+    networking.kserve.io/route: |
+      - destination:
+          host: reefguard-predictor-predictor-default.default.svc.cluster.local
+        weight: 90
+      - destination:
+          host: reefguard-predictor-predictor-canary.default.svc.cluster.local
+        weight: 10
+spec:
+  predictor:
+    containers:
+      - image: gcr.io/reefguard/predictor:v1
+  canary:
+    predictor:
+      containers:
+        - image: gcr.io/reefguard/predictor:v2


### PR DESCRIPTION
## Summary
- add simple KFServing Predictor class
- provide Dockerfile to run model server
- define KFServing InferenceService with Istio traffic-splitting annotations

## Testing
- `python -m py_compile models/inference/predictor.py`
- `pytest -q`