### PR TITLE
Add Terraform infrastructure modules and Helmfile for MLOps

### DIFF
--- a/infra/helmfile/helmfile.yaml
+++ b/infra/helmfile/helmfile.yaml
@@ -1,0 +1,36 @@
+repositories:
+  - name: feast
+    url: https://feast-helm-charts.storage.googleapis.com
+  - name: bitnami
+    url: https://charts.bitnami.com/bitnami
+  - name: jetstack
+    url: https://charts.jetstack.io
+
+releases:
+  - name: cert-manager
+    namespace: cert-manager
+    chart: jetstack/cert-manager
+    version: v1.13.2
+    set:
+      - name: installCRDs
+        value: true
+
+  - name: kfserving
+    namespace: kfserving
+    chart: https://github.com/kserve/kserve/releases/download/v0.15.2/helm-chart-kserve-v0.15.2.tgz
+
+  - name: feast
+    namespace: feast
+    chart: feast/feast
+
+  - name: mlflow
+    namespace: mlflow
+    chart: bitnami/mlflow
+
+  - name: postgresql
+    namespace: mlflow
+    chart: bitnami/postgresql
+
+  - name: minio
+    namespace: mlflow
+    chart: bitnami/minio

--- a/infra/terraform/core/eks/main.tf
+++ b/infra/terraform/core/eks/main.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+resource "aws_eks_cluster" "this" {
+  name     = var.name
+  role_arn = var.role_arn
+  version  = var.cluster_version
+
+  vpc_config {
+    subnet_ids = var.subnet_ids
+  }
+
+  tags = var.tags
+}

--- a/infra/terraform/core/eks/outputs.tf
+++ b/infra/terraform/core/eks/outputs.tf
@@ -1,0 +1,14 @@
+output "cluster_id" {
+  description = "EKS cluster ID"
+  value       = aws_eks_cluster.this.id
+}
+
+output "endpoint" {
+  description = "API server endpoint"
+  value       = aws_eks_cluster.this.endpoint
+}
+
+output "ca_certificate" {
+  description = "Base64 encoded certificate data"
+  value       = aws_eks_cluster.this.certificate_authority[0].data
+}

--- a/infra/terraform/core/eks/variables.tf
+++ b/infra/terraform/core/eks/variables.tf
@@ -1,0 +1,26 @@
+variable "name" {
+  description = "Name of the EKS cluster"
+  type        = string
+}
+
+variable "role_arn" {
+  description = "IAM role ARN for the EKS cluster"
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "Subnets associated with the cluster"
+  type        = list(string)
+}
+
+variable "cluster_version" {
+  description = "Kubernetes version for the cluster"
+  type        = string
+  default     = "1.29"
+}
+
+variable "tags" {
+  description = "Additional tags to apply"
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/core/s3/main.tf
+++ b/infra/terraform/core/s3/main.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+resource "aws_s3_bucket" "this" {
+  bucket = var.name
+  acl    = var.acl
+
+  tags = var.tags
+}

--- a/infra/terraform/core/s3/outputs.tf
+++ b/infra/terraform/core/s3/outputs.tf
@@ -1,0 +1,9 @@
+output "bucket" {
+  description = "Name of the bucket"
+  value       = aws_s3_bucket.this.bucket
+}
+
+output "arn" {
+  description = "ARN of the bucket"
+  value       = aws_s3_bucket.this.arn
+}

--- a/infra/terraform/core/s3/variables.tf
+++ b/infra/terraform/core/s3/variables.tf
@@ -1,0 +1,16 @@
+variable "name" {
+  description = "Bucket name"
+  type        = string
+}
+
+variable "acl" {
+  description = "Canned ACL to apply"
+  type        = string
+  default     = "private"
+}
+
+variable "tags" {
+  description = "Additional tags"
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/core/vpc/main.tf
+++ b/infra/terraform/core/vpc/main.tf
@@ -1,0 +1,42 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+resource "aws_vpc" "this" {
+  cidr_block           = var.cidr_block
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = merge(var.tags, {
+    Name = var.name
+  })
+}
+
+resource "aws_subnet" "public" {
+  for_each = var.public_subnet_cidrs
+
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = each.value
+  map_public_ip_on_launch = true
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-public-${each.key}"
+  })
+}
+
+resource "aws_subnet" "private" {
+  for_each = var.private_subnet_cidrs
+
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = each.value
+  map_public_ip_on_launch = false
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-private-${each.key}"
+  })
+}

--- a/infra/terraform/core/vpc/outputs.tf
+++ b/infra/terraform/core/vpc/outputs.tf
@@ -1,0 +1,14 @@
+output "vpc_id" {
+  description = "ID of the created VPC"
+  value       = aws_vpc.this.id
+}
+
+output "public_subnet_ids" {
+  description = "IDs of the public subnets"
+  value       = [for s in aws_subnet.public : s.id]
+}
+
+output "private_subnet_ids" {
+  description = "IDs of the private subnets"
+  value       = [for s in aws_subnet.private : s.id]
+}

--- a/infra/terraform/core/vpc/variables.tf
+++ b/infra/terraform/core/vpc/variables.tf
@@ -1,0 +1,25 @@
+variable "name" {
+  description = "Name prefix for the VPC and subnets"
+  type        = string
+}
+
+variable "cidr_block" {
+  description = "CIDR block for the VPC"
+  type        = string
+}
+
+variable "public_subnet_cidrs" {
+  description = "Map of public subnet CIDR blocks"
+  type        = map(string)
+}
+
+variable "private_subnet_cidrs" {
+  description = "Map of private subnet CIDR blocks"
+  type        = map(string)
+}
+
+variable "tags" {
+  description = "Additional tags to apply"
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/mlops/ecr/main.tf
+++ b/infra/terraform/mlops/ecr/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+resource "aws_ecr_repository" "this" {
+  name                 = var.name
+  image_tag_mutability = var.image_tag_mutability
+
+  image_scanning_configuration {
+    scan_on_push = var.scan_on_push
+  }
+
+  tags = var.tags
+}

--- a/infra/terraform/mlops/ecr/outputs.tf
+++ b/infra/terraform/mlops/ecr/outputs.tf
@@ -1,0 +1,9 @@
+output "repository_url" {
+  description = "URL of the ECR repository"
+  value       = aws_ecr_repository.this.repository_url
+}
+
+output "arn" {
+  description = "ARN of the repository"
+  value       = aws_ecr_repository.this.arn
+}

--- a/infra/terraform/mlops/ecr/variables.tf
+++ b/infra/terraform/mlops/ecr/variables.tf
@@ -1,0 +1,22 @@
+variable "name" {
+  description = "Name of the ECR repository"
+  type        = string
+}
+
+variable "image_tag_mutability" {
+  description = "Tag mutability setting for the repository"
+  type        = string
+  default     = "MUTABLE"
+}
+
+variable "scan_on_push" {
+  description = "Enable image scanning on push"
+  type        = bool
+  default     = true
+}
+
+variable "tags" {
+  description = "Additional tags"
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/mlops/monitoring/main.tf
+++ b/infra/terraform/mlops/monitoring/main.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_group" "this" {
+  name              = var.name
+  retention_in_days = var.retention_in_days
+
+  tags = var.tags
+}

--- a/infra/terraform/mlops/monitoring/outputs.tf
+++ b/infra/terraform/mlops/monitoring/outputs.tf
@@ -1,0 +1,4 @@
+output "log_group_arn" {
+  description = "ARN of the log group"
+  value       = aws_cloudwatch_log_group.this.arn
+}

--- a/infra/terraform/mlops/monitoring/variables.tf
+++ b/infra/terraform/mlops/monitoring/variables.tf
@@ -1,0 +1,16 @@
+variable "name" {
+  description = "Name of the CloudWatch log group"
+  type        = string
+}
+
+variable "retention_in_days" {
+  description = "Retention period for logs"
+  type        = number
+  default     = 14
+}
+
+variable "tags" {
+  description = "Additional tags"
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/mlops/sagemaker/main.tf
+++ b/infra/terraform/mlops/sagemaker/main.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+resource "aws_sagemaker_notebook_instance" "this" {
+  name          = var.name
+  role_arn      = var.role_arn
+  instance_type = var.instance_type
+
+  tags = var.tags
+}

--- a/infra/terraform/mlops/sagemaker/outputs.tf
+++ b/infra/terraform/mlops/sagemaker/outputs.tf
@@ -1,0 +1,4 @@
+output "notebook_arn" {
+  description = "ARN of the notebook instance"
+  value       = aws_sagemaker_notebook_instance.this.arn
+}

--- a/infra/terraform/mlops/sagemaker/variables.tf
+++ b/infra/terraform/mlops/sagemaker/variables.tf
@@ -1,0 +1,21 @@
+variable "name" {
+  description = "Name of the notebook instance"
+  type        = string
+}
+
+variable "role_arn" {
+  description = "Execution role for the notebook"
+  type        = string
+}
+
+variable "instance_type" {
+  description = "SageMaker notebook instance type"
+  type        = string
+  default     = "ml.t3.medium"
+}
+
+variable "tags" {
+  description = "Additional tags"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## Summary
- add core Terraform modules for VPC networking, EKS cluster, and S3 storage
- add MLOps Terraform modules for ECR, SageMaker notebook, and CloudWatch monitoring
- provision Helmfile manifest installing cert-manager, KServe, Feast, MLflow, Postgres, and MinIO

## Testing
- `terraform init -backend=false && terraform validate` (vpc, eks, s3, ecr, sagemaker, monitoring)
- `helmfile -f infra/helmfile/helmfile.yaml lint`