### PR TITLE
Add ViT-XGBoost ensemble model and tests

### DIFF
--- a/models/trainer/model.py
+++ b/models/trainer/model.py
@@ -1,0 +1,122 @@
+"""Model definition for training.
+
+This module provides a small ensemble that marries a Vision Transformer
+feature extractor with an XGBoost classifier.  The Vision Transformer is
+responsible for converting images into dense feature vectors.  These
+features are then used by the XGBoost model to produce final predictions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+import torch
+from torch import nn
+import torchvision.models as tv_models
+import xgboost as xgb
+
+
+@dataclass
+class EnsembleModel:
+    """Ensemble of a Vision Transformer and an XGBoost classifier.
+
+    Parameters
+    ----------
+    vit:
+        The Vision Transformer feature extractor.  The classifier head is
+        expected to be removed so that calling the model returns feature
+        embeddings.
+    xgb_model:
+        The XGBoost classifier receiving the Vision Transformer embeddings.
+    """
+
+    vit: nn.Module
+    xgb_model: xgb.XGBClassifier
+
+    def _extract_features(self, images: np.ndarray) -> np.ndarray:
+        """Extract embeddings from images using the Vision Transformer.
+
+        Parameters
+        ----------
+        images:
+            Array of shape ``(N, C, H, W)`` representing a batch of images.
+
+        Returns
+        -------
+        np.ndarray
+            Feature matrix of shape ``(N, F)`` where ``F`` is the embedding
+            dimension of the Vision Transformer.
+        """
+
+        self.vit.eval()
+        with torch.no_grad():
+            if isinstance(images, np.ndarray):
+                # ``torch.from_numpy`` cannot be used in some environments where
+                # PyTorch was built against an older NumPy version.  Converting
+                # via ``tolist`` avoids reliance on NumPy's C-API which keeps
+                # the function lightweight for small test tensors.
+                tensor = torch.tensor(images.tolist(), dtype=torch.float32)
+            else:  # assume ``torch.Tensor``
+                tensor = images.float()
+            if tensor.ndim == 3:
+                tensor = tensor.unsqueeze(0)
+            features = self.vit(tensor)
+        # Avoid ``Tensor.numpy`` which requires a NumPy version matching the
+        # one used during PyTorch compilation.  Converting via ``tolist`` keeps
+        # the dependency minimal and works in constrained environments.
+        return np.array(features.detach().cpu().tolist())
+
+    def fit(self, images: np.ndarray, labels: np.ndarray, **kwargs: Any) -> None:
+        """Train the ensemble on the provided images and labels.
+
+        Parameters
+        ----------
+        images:
+            Training images as a numpy array.
+        labels:
+            Corresponding labels for ``images``.
+        **kwargs:
+            Additional keyword arguments passed to
+            :meth:`xgboost.XGBClassifier.fit`.
+        """
+
+        features = self._extract_features(images)
+        self.xgb_model.fit(features, labels, **kwargs)
+
+    def predict(self, images: np.ndarray) -> np.ndarray:
+        """Predict labels for the given images.
+
+        Parameters
+        ----------
+        images:
+            Images to classify.
+
+        Returns
+        -------
+        np.ndarray
+            Predicted class labels.
+        """
+
+        features = self._extract_features(images)
+        return self.xgb_model.predict(features)
+
+
+def build_model() -> EnsembleModel:
+    """Create a default Vision Transformer + XGBoost ensemble.
+
+    The Vision Transformer is initialised without pretrained weights and its
+    classification head is replaced by an identity layer so that the model
+    outputs raw embeddings.
+
+    Returns
+    -------
+    EnsembleModel
+        A ready-to-train ensemble instance.
+    """
+
+    vit = tv_models.vit_b_16(weights=None)
+    vit.heads = nn.Identity()
+    xgb_model = xgb.XGBClassifier()
+    return EnsembleModel(vit=vit, xgb_model=xgb_model)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 evidently
 pandas
 requests
+torch
+torchvision
+xgboost

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,50 @@
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import numpy as np
+import torch
+from torch import nn
+
+# Ensure repository root on path so ``models`` can be imported when tests are
+# executed from a clean environment.
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:  # pragma: no cover - sanity check
+    sys.path.insert(0, str(ROOT))
+
+from models.trainer.model import EnsembleModel, build_model
+
+
+def test_build_model_returns_ensemble():
+    model = build_model()
+    assert isinstance(model, EnsembleModel)
+    # basic sanity checks on inner models
+    assert isinstance(model.vit, nn.Module)
+    from xgboost import XGBClassifier
+
+    assert isinstance(model.xgb_model, XGBClassifier)
+
+
+def test_ensemble_fit_predict_calls_underlying_models():
+    class DummyViT(nn.Module):
+        def forward(self, x: torch.Tensor) -> torch.Tensor:  # pragma: no cover - trivial
+            batch = x.shape[0]
+            return torch.ones((batch, 4))
+
+    vit = DummyViT()
+    xgb = MagicMock()
+    xgb.predict.return_value = np.array([0, 1])
+
+    ensemble = EnsembleModel(vit=vit, xgb_model=xgb)
+
+    images = np.zeros((2, 3, 32, 32), dtype=np.float32)
+    labels = np.array([0, 1])
+
+    ensemble.fit(images, labels)
+    # Ensure XGBoost received features with correct shape
+    args, _ = xgb.fit.call_args
+    assert args[0].shape == (2, 4)
+
+    preds = ensemble.predict(images)
+    xgb.predict.assert_called_once()
+    assert preds.shape == (2,)


### PR DESCRIPTION
## Summary
- implement Vision Transformer + XGBoost ensemble model with factory builder
- add unit tests covering build and ensemble interactions
- declare torch, torchvision and xgboost dependencies

## Testing
- `pytest -q`