### PR TITLE
Add retrain-on-drift pipeline and integrate with drift job

### DIFF
--- a/helm/observability/templates/drift-cronjob.yaml
+++ b/helm/observability/templates/drift-cronjob.yaml
@@ -15,5 +15,5 @@ spec:
             env:
             - name: PSI_THRESHOLD
               value: {{ .Values.DriftJob.psiThreshold | quote }}
-            - name: RETRAIN_ENDPOINT
-              value: {{ .Values.DriftJob.retrainEndpoint | quote }}
+            - name: KFP_HOST
+              value: {{ .Values.DriftJob.kfpHost | quote }}

--- a/helm/observability/values.yaml
+++ b/helm/observability/values.yaml
@@ -28,4 +28,4 @@ DriftJob:
   schedule: "*/30 * * * *"
   image: ghcr.io/reefguard/drift-job:latest
   psiThreshold: 0.2
-  retrainEndpoint: http://retrainer/retrain
+  kfpHost: http://ml-pipeline.kubeflow.svc.cluster.local:8888

--- a/jobs/drift_evaluation.py
+++ b/jobs/drift_evaluation.py
@@ -1,46 +1,20 @@
-"""Periodic drift evaluation job triggering retraining when PSI exceeds threshold."""
+"""Periodic job submitting retrain-on-drift pipeline."""
 import os
-import pandas as pd
-import requests
-from evidently.report import Report
-from evidently.metrics import DataDriftTable
+from kfp import Client
+
+from pipelines.kfp_v2.retrain_on_drift import retrain_on_drift
 
 PSI_THRESHOLD = float(os.getenv("PSI_THRESHOLD", "0.2"))
-RETRAIN_ENDPOINT = os.getenv("RETRAIN_ENDPOINT", "http://retrainer/retrain")
-
-
-def load_data():
-    """Load reference and current datasets.
-
-    This function expects CSV files `data/reference.csv` and
-    `data/current.csv` to be mounted into the container. In a real
-    deployment these would come from a data lake or feature store.
-    """
-    reference = pd.read_csv("data/reference.csv")
-    current = pd.read_csv("data/current.csv")
-    return reference, current
-
-
-def compute_psi(reference: pd.DataFrame, current: pd.DataFrame) -> float:
-    """Compute the Population Stability Index using Evidently."""
-    report = Report(metrics=[DataDriftTable()])
-    report.run(reference_data=reference, current_data=current)
-    metrics = report.as_dict()["metrics"][0]["result"]
-    # DataDriftTable returns share of drifted columns; treat as PSI
-    return metrics.get("share_drifted_columns", 0.0)
-
-
-def trigger_retraining():
-    """Invoke retraining pipeline via REST endpoint."""
-    response = requests.post(RETRAIN_ENDPOINT, timeout=10)
-    response.raise_for_status()
+KFP_HOST = os.getenv("KFP_HOST", "http://ml-pipeline.kubeflow.svc.cluster.local:8888")
 
 
 def main() -> None:
-    reference, current = load_data()
-    psi = compute_psi(reference, current)
-    if psi > PSI_THRESHOLD:
-        trigger_retraining()
+    """Submit the retraining pipeline with the configured PSI threshold."""
+    client = Client(host=KFP_HOST)
+    client.create_run_from_pipeline_func(
+        retrain_on_drift,
+        arguments={"psi_threshold": PSI_THRESHOLD},
+    )
 
 
 if __name__ == "__main__":

--- a/pipelines/kfp_v2/retrain_on_drift.py
+++ b/pipelines/kfp_v2/retrain_on_drift.py
@@ -1,0 +1,42 @@
+"""Kubeflow pipeline retraining the model when PSI exceeds a threshold."""
+from __future__ import annotations
+
+from kfp import dsl
+from kfp.dsl import component
+
+from .training_pipeline import training_pipeline
+
+
+@component(base_image="python:3.10", packages_to_install=["pandas", "evidently"])
+def compute_psi(reference_path: str, current_path: str) -> float:
+    """Compute the Population Stability Index between two datasets."""
+    import pandas as pd
+    from evidently.report import Report
+    from evidently.metrics import DataDriftTable
+
+    reference = pd.read_csv(reference_path)
+    current = pd.read_csv(current_path)
+    report = Report(metrics=[DataDriftTable()])
+    report.run(reference_data=reference, current_data=current)
+    metrics = report.as_dict()["metrics"][0]["result"]
+    return float(metrics.get("share_drifted_columns", 0.0))
+
+
+@dsl.pipeline(
+    name="retrain-on-drift",
+    description="Compute PSI and run training pipeline if drift detected",
+)
+def retrain_on_drift(
+    psi_threshold: float = 0.2,
+    reference_path: str = "data/reference.csv",
+    current_path: str = "data/current.csv",
+):
+    psi_task = compute_psi(reference_path=reference_path, current_path=current_path)
+    with dsl.Condition(psi_task.output > psi_threshold):
+        training_pipeline()
+
+
+if __name__ == "__main__":
+    from kfp.v2 import compiler
+
+    compiler.Compiler().compile(retrain_on_drift, package_path="retrain_on_drift.json")


### PR DESCRIPTION
## Summary
- add a KFP v2 pipeline that retrains the model when PSI exceeds a threshold
- submit this pipeline from the drift evaluation job
- update Helm DriftJob configuration to pass KFP host

## Testing
- `pytest`