### PR TITLE
Use AIMS Weather API for buoy telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ graph TD;
 | ----------------------------- | --------- | --------------- | -------------------- |
 | Sentinel‑2 L2A surface‑temp   | COG       | Daily tiles     | AWS Open Data Bucket |
 | MODIS Sea‑Surface Temperature | HDF       | Daily composite | NASA OPeNDAP         |
-| Queensland IMOS buoys         | JSON REST | Every 10 min    | Public API           |
+| Queensland IMOS buoys         | JSON REST | Every 10 min    | AIMS Weather API (API key) |
 
 ---
 


### PR DESCRIPTION
## Summary
- Query Queensland IMOS/AIMS buoy data from the AIMS Weather API instead of placeholder URLs
- Add station ID and optional API key parameters with error handling
- Document API key requirement in data sources table

## Testing
- `python -m py_compile pipelines/kfp_v2/etl_pipeline.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f3433a4348329aecaea04b650ff7c