### PR TITLE
Add unit tests for core pipelines and models

### DIFF
--- a/tests/test_etl.py
+++ b/tests/test_etl.py
@@ -1,0 +1,146 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+import requests
+
+
+def load_etl_module(monkeypatch):
+    """Import the ETL pipeline module with stubbed kfp dependency."""
+    kfp_module = types.ModuleType("kfp")
+    dsl_module = types.ModuleType("dsl")
+
+    def _passthrough_decorator(*_args, **_kwargs):
+        def wrapper(func):
+            return func
+        return wrapper
+
+    dsl_module.component = _passthrough_decorator
+    dsl_module.pipeline = _passthrough_decorator
+    kfp_module.dsl = dsl_module
+
+    monkeypatch.setitem(sys.modules, "kfp", kfp_module)
+    monkeypatch.setitem(sys.modules, "kfp.dsl", dsl_module)
+
+    spec = importlib.util.spec_from_file_location(
+        "etl_pipeline", Path("pipelines/kfp_v2/etl_pipeline.py")
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_pull_sentinel2(monkeypatch):
+    etl = load_etl_module(monkeypatch)
+
+    class MockPost:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {
+                "features": [
+                    {"assets": {"visual": {"href": "http://example.com/vis.tif"}}}
+                ]
+            }
+
+    class MockGet:
+        content = b"image"
+
+    monkeypatch.setattr(requests, "post", lambda *a, **k: MockPost())
+    monkeypatch.setattr(requests, "get", lambda *a, **k: MockGet())
+
+    class DummyS3:
+        def __init__(self):
+            self.calls = []
+
+        def put_object(self, Bucket, Key, Body):
+            self.calls.append((Bucket, Key, Body))
+
+    s3_client = DummyS3()
+
+    def client(service, endpoint_url=None):
+        assert service == "s3"
+        return s3_client
+
+    monkeypatch.setitem(sys.modules, "boto3", types.SimpleNamespace(client=client))
+
+    result = etl.pull_sentinel2(
+        lakefs_endpoint="http://lakefs",
+        bucket="bucket",
+        prefix="prefix",
+        region="0,0,1,1",
+        start_date="2023-01-01",
+        end_date="2023-01-02",
+    )
+
+    assert result == "s3://bucket/prefix/sentinel2_visual.tif"
+
+
+def test_pull_modis_sst(monkeypatch):
+    etl = load_etl_module(monkeypatch)
+
+    class MockGet:
+        content = b"sst"
+
+    monkeypatch.setattr(requests, "get", lambda *a, **k: MockGet())
+
+    class DummyS3:
+        def __init__(self):
+            self.calls = []
+
+        def put_object(self, Bucket, Key, Body):
+            self.calls.append((Bucket, Key, Body))
+
+    s3_client = DummyS3()
+
+    def client(service, endpoint_url=None):
+        assert service == "s3"
+        return s3_client
+
+    monkeypatch.setitem(sys.modules, "boto3", types.SimpleNamespace(client=client))
+
+    result = etl.pull_modis_sst(
+        lakefs_endpoint="http://lakefs",
+        bucket="bucket",
+        prefix="prefix",
+        date="2023-001",
+    )
+
+    assert result == "s3://bucket/prefix/modis_sst_2023-001.nc"
+
+
+def test_pull_qld_buoy(monkeypatch):
+    etl = load_etl_module(monkeypatch)
+
+    class MockGet:
+        content = b"buoy"
+
+    monkeypatch.setattr(requests, "get", lambda *a, **k: MockGet())
+
+    class DummyS3:
+        def __init__(self):
+            self.calls = []
+
+        def put_object(self, Bucket, Key, Body):
+            self.calls.append((Bucket, Key, Body))
+
+    s3_client = DummyS3()
+
+    def client(service, endpoint_url=None):
+        assert service == "s3"
+        return s3_client
+
+    monkeypatch.setitem(sys.modules, "boto3", types.SimpleNamespace(client=client))
+
+    result = etl.pull_qld_buoy(
+        lakefs_endpoint="http://lakefs",
+        bucket="bucket",
+        prefix="prefix",
+        station_id="station-001",
+    )
+
+    assert result == "s3://bucket/prefix/buoy_station-001.json"

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1,0 +1,39 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+def load_predictor(monkeypatch):
+    """Import predictor module with a stubbed kserve package."""
+    kserve_module = types.ModuleType("kserve")
+
+    class KFModel:
+        def __init__(self, name):
+            self.name = name
+
+    class ModelServer:
+        def start(self, models):
+            return None
+
+    kserve_module.KFModel = KFModel
+    kserve_module.ModelServer = ModelServer
+
+    monkeypatch.setitem(sys.modules, "kserve", kserve_module)
+    spec = importlib.util.spec_from_file_location(
+        "predictor", Path("models/inference/predictor.py")
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_predictor(monkeypatch):
+    module = load_predictor(monkeypatch)
+    predictor = module.Predictor("reefguard-model")
+    assert not predictor.ready
+    predictor.load()
+    assert predictor.ready
+    result = predictor.predict({"instances": [1, 2, 3]})
+    assert result == {"predictions": [1, 2, 3]}

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -1,0 +1,56 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def load_train_module(monkeypatch):
+    """Import training module with a stubbed mlflow package."""
+    logged: dict[str, float | bool] = {}
+
+    mlflow_module = types.ModuleType("mlflow")
+
+    class DummyRun:
+        def __enter__(self):
+            return None
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    mlflow_module.start_run = lambda: DummyRun()
+    mlflow_module.log_metric = lambda k, v: logged.setdefault(k, v)
+
+    class SklearnModule:
+        @staticmethod
+        def log_model(model, artifact_path):
+            logged["model_logged"] = True
+
+    sklearn_module = SklearnModule()
+    mlflow_module.sklearn = sklearn_module
+    monkeypatch.setitem(sys.modules, "mlflow.sklearn", sklearn_module)
+    mlflow_module.get_artifact_uri = lambda path: f"/tmp/{path}"
+
+    class DummyResult:
+        name = "model"
+        version = 1
+
+    mlflow_module.register_model = lambda uri, name: DummyResult()
+
+    monkeypatch.setitem(sys.modules, "mlflow", mlflow_module)
+
+    spec = importlib.util.spec_from_file_location(
+        "train", Path("models/trainer/train.py")
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module, logged
+
+
+def test_train_runs(monkeypatch):
+    module, logged = load_train_module(monkeypatch)
+    args = SimpleNamespace(model_name="model", experiment="exp")
+    module.train(args)
+    assert "accuracy" in logged
+    assert logged["model_logged"] is True


### PR DESCRIPTION
## Summary
- add tests for ETL components `pull_sentinel2`, `pull_modis_sst`, and `pull_qld_buoy`
- add tests validating `train` MLflow integration and `Predictor` inference behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f343667008329a582158f9382de9c