### PR TITLE
docs: expand project documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,78 @@
-# Documentation
+# ReefGuard AI Documentation
 
-Placeholder for project documentation.
+This guide expands on the project architecture, local development workflow, and common troubleshooting steps. It also collects diagrams referenced in the top level README for easier access.
+
+## Architecture Overview
+
+ReefGuard AI orchestrates ingestion, feature management, model training, registry, serving and monitoring for coral-bleaching risk prediction.
+
+```mermaid
+graph TD;
+  subgraph Data_Ingestion
+    S2[Sentinel‑2 Tiles]-->ETL(KF ETF step)
+    MODIS[MODIS SST]-->ETL
+    Buoys[QLD Buoy API]-->ETL
+  end
+  ETL-->Lake[lakeFS @ S3 BRONZE]
+  Lake-->Features(Feast Offline Store)
+  Features-->Katib[Katib Tuner]
+  Katib-->Train[Training Pipeline]
+  Train-->MLflow[MLflow Registry]
+  MLflow-->|Policies OK| Staging(Staging Model)
+  subgraph CI
+    PR-->Checks[GitHub Action 'model-ci']
+    Checks-->MLflow
+  end
+  Staging-->Canary(KFServing canary 10%)
+  Canary-->Live(100% traffic v2)
+  Canary-->Monitor(Evidently AI Drift)
+  Monitor-->|Drift > PSI| Katib
+```
+
+* **Ingestion** – satellite tiles and buoy readings land in lakeFS-backed object storage.
+* **Feature Store** – Feast materialises features to Parquet and Redis.
+* **Training & Tuning** – Kubeflow Pipelines invoke training jobs tuned by Katib.
+* **Model Registry** – MLflow tracks experiments and governs stage transitions.
+* **Serving** – KFServing or SageMaker deploy models with canary rollout.
+* **Monitoring** – Evidently exports drift metrics to Prometheus and Grafana.
+
+## Local Setup
+
+1. Clone the repository and create an isolated environment.
+   ```bash
+   git clone https://github.com/example/Australian_ReefGuard-AI.git
+   cd Australian_ReefGuard-AI
+   python -m venv .venv && source .venv/bin/activate
+   pip install -r requirements.txt
+   ```
+2. Launch local services for tracking and feature definitions.
+   ```bash
+   mlflow server --backend-store-uri sqlite:///mlflow.db --default-artifact-root ./mlruns &
+   feast apply
+   ```
+3. Ingest sample data and run a training job.
+   ```bash
+   python pipelines/kfp_v2/etl_pipeline.py --local-sample
+   python models/trainer/train.py --sample-data
+   ```
+4. Serve the latest model and query it.
+   ```bash
+   python models/inference/app.py --model-path models/artifacts/latest &
+   curl -X POST -H "Content-Type: application/json" \
+     -d '{"features": {"sst": 28.4, "turbidity": 3.1}}' \
+     http://localhost:8000/predict
+   ```
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+| --- | --- | --- |
+| `mlflow.exceptions.MlflowException: Permission` | MLflow ingress auth misconfigured | Ensure Cognito group `mlops-admins` attached |
+| Katib trial pods stuck Pending | GPU quota exceeded | Adjust `nvidia.com/gpu: 0` for CPU trials or request quota |
+| Feast online lookup timeout | Redis eviction | Increase memory or set LRU policy |
+| KFServing 503 | Istio sidecar missing | Namespace not labeled `istio-injection=enabled` |
+| Evidently service 500 | Missing numpy-rocm wheel | Rebuild image targeting GPU arch or use CPU mode |
+
+## Diagrams
+
+The end-to-end workflow diagram above mirrors the one in the project README. Grafana panels for drift, latency, and heat-map visualisations are defined in [`grafana_dash.json`](grafana_dash.json).

--- a/docs/demo_script.md
+++ b/docs/demo_script.md
@@ -6,8 +6,8 @@ This walkthrough demonstrates an end-to-end run of the ReefGuard AI pipeline on 
    ```bash
    git clone https://github.com/example/Australian_ReefGuard-AI.git
    cd Australian_ReefGuard-AI
-   conda create -n reefguard python=3.11 -y && conda activate reefguard
-   pip install -r requirements-dev.txt
+   python -m venv .venv && source .venv/bin/activate
+   pip install -r requirements.txt
    ```
 2. **Launch local services** – start MLflow for experiment tracking and apply Feast feature definitions.
    ```bash
@@ -24,7 +24,7 @@ This walkthrough demonstrates an end-to-end run of the ReefGuard AI pipeline on 
    ```
 5. **Serve the model** – launch a simple inference service.
    ```bash
-   python models/inference/app.py --model-path models/artifacts/latest
+   python models/inference/app.py --model-path models/artifacts/latest &
    ```
 6. **Query the endpoint** – send a test request and review the prediction.
    ```bash
@@ -32,6 +32,7 @@ This walkthrough demonstrates an end-to-end run of the ReefGuard AI pipeline on 
         -d '{"features": {"sst": 28.4, "turbidity": 3.1}}' \
         http://localhost:8000/predict
    ```
-7. **Clean up** – stop background services and remove temporary files.
+7. **Monitor** – import `docs/grafana_dash.json` into Grafana to view PSI drift, latency and heat-map panels.
+8. **Clean up** – stop background services and remove temporary files.
 
 These steps can be adapted for live infrastructure by swapping the local commands for their Kubernetes or Terraform equivalents.

--- a/docs/grafana_dash.json
+++ b/docs/grafana_dash.json
@@ -2,8 +2,24 @@
   "title": "ReefGuard Observability",
   "panels": [
     {
+      "type": "heatmap",
+      "title": "Bleach Risk Heat Map",
+      "datasource": "Prometheus",
+      "targets": [
+        { "expr": "bleach_risk_score" }
+      ]
+    },
+    {
       "type": "graph",
-      "title": "PSI Drift",
+      "title": "Model Latency P95",
+      "datasource": "Prometheus",
+      "targets": [
+        { "expr": "histogram_quantile(0.95, sum(rate(inference_request_duration_seconds_bucket[5m])) by (le))" }
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "Data Drift PSI",
       "datasource": "Prometheus",
       "targets": [
         { "expr": "psi_drift_metric" }


### PR DESCRIPTION
## Summary
- Flesh out docs README with architecture overview, local setup guidance, troubleshooting table, and diagram references
- Align demo script with current features and reference Grafana dashboard
- Expand Grafana dashboard JSON to include heat map, latency, and PSI drift panels

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688f3436d3ac8329a515b699b19f0f65