### PR TITLE
Move inference Dockerfile and update image references

### DIFF
--- a/.github/workflows/model-ci.yml
+++ b/.github/workflows/model-ci.yml
@@ -32,4 +32,4 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Build Docker image
-        run: docker build -t reefguard-ai .
+        run: docker build -t reefguard-ai models/inference

--- a/models/inference/Dockerfile
+++ b/models/inference/Dockerfile
@@ -4,10 +4,11 @@ FROM python:3.9-slim
 WORKDIR /app
 
 # Copy predictor implementation
-COPY models/inference/predictor.py predictor.py
+COPY predictor.py predictor.py
 
 # Install required dependencies
-RUN pip install --no-cache-dir kserve
+RUN pip install --no-cache-dir kserve mlflow pandas torch \
+    && (pip install --no-cache-dir feast || true)
 
 # Run the predictor with KFServing ModelServer
 CMD ["python", "predictor.py"]

--- a/serving/inference_service.yaml
+++ b/serving/inference_service.yaml
@@ -15,8 +15,8 @@ metadata:
 spec:
   predictor:
     containers:
-      - image: gcr.io/reefguard/predictor:v1
+      - image: gcr.io/reefguard/reefguard-ai:v1
   canary:
     predictor:
       containers:
-        - image: gcr.io/reefguard/predictor:v2
+        - image: gcr.io/reefguard/reefguard-ai:v2


### PR DESCRIPTION
## Summary
- move predictor Dockerfile under `models/inference` and install mlflow, pandas, torch and optional feast
- build the inference image from the new path in the CI workflow
- reference the new inference image in the serving manifest

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f3963a9f48329a32ea3ffbd65d271