### PR TITLE
Align training pipeline with trainer CLI flags

### DIFF
--- a/pipelines/kfp_v2/README.md
+++ b/pipelines/kfp_v2/README.md
@@ -1,3 +1,19 @@
 # KFP v2 Pipelines
 
-Placeholder for Kubeflow Pipelines v2 definitions.
+Kubeflow Pipelines v2 definitions for ReefGuard AI.
+
+## Training Pipeline
+
+The training pipeline submits a Katib experiment that tunes the XGBoost
+hyperparameters passed to `models/trainer/train.py` via
+`--xgb-learning-rate` and `--xgb-max-depth`.
+
+Recompile the pipeline JSON after making changes:
+
+```bash
+python - <<'PY'
+from kfp import compiler
+from pipelines.kfp_v2.training_pipeline import training_pipeline
+compiler.Compiler().compile(training_pipeline, package_path='pipelines/kfp_v2/training_pipeline.json')
+PY
+```

--- a/pipelines/kfp_v2/training_pipeline.json
+++ b/pipelines/kfp_v2/training_pipeline.json
@@ -1,0 +1,66 @@
+{
+  "components": {
+    "comp-katib-experiment": {
+      "executorLabel": "exec-katib-experiment",
+      "inputDefinitions": {
+        "parameters": {
+          "experiment_spec": {
+            "parameterType": "STRING"
+          }
+        }
+      }
+    }
+  },
+  "deploymentSpec": {
+    "executors": {
+      "exec-katib-experiment": {
+        "container": {
+          "command": [
+            "python",
+            "-m",
+            "kubeflow.katib.launcher",
+            "--experiment-name",
+            "reefguard-bayesian",
+            "--experiment-namespace",
+            "kubeflow",
+            "--experiment-spec",
+            "{{$.inputs.parameters['experiment_spec']}}"
+          ],
+          "image": "docker.io/kubeflowkatib/katib-launcher:latest"
+        }
+      }
+    }
+  },
+  "pipelineInfo": {
+    "description": "Training pipeline with Katib Bayesian HPO",
+    "name": "reefguard-training-pipeline"
+  },
+  "root": {
+    "dag": {
+      "tasks": {
+        "katib-experiment": {
+          "cachingOptions": {
+            "enableCache": true
+          },
+          "componentRef": {
+            "name": "comp-katib-experiment"
+          },
+          "inputs": {
+            "parameters": {
+              "experiment_spec": {
+                "runtimeValue": {
+                  "constant": "{\"apiVersion\": \"kubeflow.org/v1beta1\", \"kind\": \"Experiment\", \"metadata\": {\"name\": \"reefguard-bayesian\"}, \"spec\": {\"objective\": {\"type\": \"maximize\", \"goal\": 0.9, \"objectiveMetricName\": \"accuracy\"}, \"algorithm\": {\"algorithmName\": \"bayesianoptimization\"}, \"parameters\": [{\"name\": \"learningRate\", \"parameterType\": \"double\", \"feasibleSpace\": {\"min\": \"0.01\", \"max\": \"0.2\"}}, {\"name\": \"maxDepth\", \"parameterType\": \"int\", \"feasibleSpace\": {\"min\": \"3\", \"max\": \"10\"}}], \"trialTemplate\": {\"primaryContainerName\": \"training-container\", \"trialParameters\": [{\"name\": \"learningRate\", \"description\": \"Learning rate for XGBoost\", \"reference\": \"learningRate\"}, {\"name\": \"maxDepth\", \"description\": \"Max depth for XGBoost\", \"reference\": \"maxDepth\"}], \"trialSpec\": {\"apiVersion\": \"batch/v1\", \"kind\": \"Job\", \"spec\": {\"template\": {\"spec\": {\"containers\": [{\"name\": \"training-container\", \"image\": \"python:3.10\", \"command\": [\"python\", \"models/trainer/train.py\"], \"args\": [\"--xgb-learning-rate\", \"${trialParameters.learningRate}\", \"--xgb-max-depth\", \"${trialParameters.maxDepth}\"]}], \"restartPolicy\": \"Never\"}}}}}}}"
+                }
+              }
+            }
+          },
+          "taskInfo": {
+            "name": "katib-experiment"
+          }
+        }
+      }
+    }
+  },
+  "schemaVersion": "2.1.0",
+  "sdkVersion": "kfp-2.13.0"
+}

--- a/pipelines/kfp_v2/training_pipeline.py
+++ b/pipelines/kfp_v2/training_pipeline.py
@@ -1,7 +1,5 @@
 """Kubeflow Pipelines v2 training pipeline invoking Katib Bayesian HPO."""
 
-from __future__ import annotations
-
 import json
 from typing import Dict
 
@@ -103,11 +101,9 @@ def training_pipeline():
                                             "models/trainer/train.py",
                                         ],
                                         "args": [
-                                            "--model",
-                                            "xgboost",
-                                            "--learning-rate",
+                                            "--xgb-learning-rate",
                                             "${trialParameters.learningRate}",
-                                            "--max-depth",
+                                            "--xgb-max-depth",
                                             "${trialParameters.maxDepth}",
                                         ],
                                     }


### PR DESCRIPTION
## Summary
- Replace deprecated training arguments with `--xgb-learning-rate` and `--xgb-max-depth`
- Document how to compile the KFP training pipeline JSON
- Regenerate `training_pipeline.json`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f396205788329b9a455939cf6ccd6