### PR TITLE
docs: reference predictor script

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,10 @@ docker build -t reefguard/trainer models/trainer
 python models/trainer/train.py --sample-data
 
 # Serve the latest model locally
-python models/inference/app.py --model-path models/artifacts/latest
+python models/inference/predictor.py --model-dir models/artifacts/latest &
+curl -X POST -H "Content-Type: application/json" \
+  -d '{"instances": [{"sst": 28.4, "turbidity": 3.1}]}' \
+  http://localhost:8080/v1/models/reefguard-model:predict
 ```
 
 ---

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,10 +57,10 @@ graph TD;
    ```
 4. Serve the latest model and query it.
    ```bash
-   python models/inference/app.py --model-path models/artifacts/latest &
+   python models/inference/predictor.py --model-dir models/artifacts/latest &
    curl -X POST -H "Content-Type: application/json" \
-     -d '{"features": {"sst": 28.4, "turbidity": 3.1}}' \
-     http://localhost:8000/predict
+     -d '{"instances": [{"sst": 28.4, "turbidity": 3.1}]}' \
+     http://localhost:8080/v1/models/reefguard-model:predict
    ```
 
 ## Troubleshooting

--- a/docs/demo_script.md
+++ b/docs/demo_script.md
@@ -24,13 +24,13 @@ This walkthrough demonstrates an end-to-end run of the ReefGuard AI pipeline on 
    ```
 5. **Serve the model** – launch a simple inference service.
    ```bash
-   python models/inference/app.py --model-path models/artifacts/latest &
+   python models/inference/predictor.py --model-dir models/artifacts/latest &
    ```
 6. **Query the endpoint** – send a test request and review the prediction.
    ```bash
    curl -X POST -H "Content-Type: application/json" \
-        -d '{"features": {"sst": 28.4, "turbidity": 3.1}}' \
-        http://localhost:8000/predict
+        -d '{"instances": [{"sst": 28.4, "turbidity": 3.1}]}' \
+        http://localhost:8080/v1/models/reefguard-model:predict
    ```
 7. **Monitor** – import `docs/grafana_dash.json` into Grafana to view PSI drift, latency and heat-map panels.
 8. **Clean up** – stop background services and remove temporary files.

--- a/models/inference/README.md
+++ b/models/inference/README.md
@@ -1,3 +1,12 @@
 # Model Inference
 
-Placeholder for inference code.
+`predictor.py` exposes a KServe-compatible server that loads an MLflow model and serves predictions.
+
+For local testing, save a model to a directory (e.g., `models/artifacts/latest`) and run:
+
+```bash
+python predictor.py --model-dir models/artifacts/latest &
+curl -X POST -H "Content-Type: application/json" \
+  -d '{"instances": [{"sst": 28.4, "turbidity": 3.1}]}' \
+  http://localhost:8080/v1/models/reefguard-model:predict
+```

--- a/models/inference/predictor.py
+++ b/models/inference/predictor.py
@@ -21,7 +21,7 @@ except Exception:  # pragma: no cover - Feast may not be installed
     FeatureStore = None
 
 
-class Predictor(kserve.KFModel):
+class Predictor(kserve.Model):
     """Model predictor for KFServing.
 
     During :meth:`load`, an MLflow model is loaded either from the supplied
@@ -58,7 +58,7 @@ class Predictor(kserve.KFModel):
 
         self.ready = True
 
-    def predict(self, request: Dict) -> Dict[str, List]:
+    def predict(self, request: Dict, headers: Dict[str, str] | None = None) -> Dict[str, List]:
         """Generate predictions from the request payload.
 
         Parameters
@@ -105,6 +105,17 @@ class Predictor(kserve.KFModel):
 
 
 if __name__ == "__main__":
-    model = Predictor("reefguard-model")
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Start a KServe predictor")
+    parser.add_argument(
+        "--model-dir",
+        dest="model_dir",
+        default=None,
+        help="Path to a local MLflow model directory",
+    )
+    args = parser.parse_args()
+
+    model = Predictor("reefguard-model", model_dir=args.model_dir)
     model.load()
     kserve.ModelServer().start([model])


### PR DESCRIPTION
## Summary
- document predictor-based serving and add CLI args for local models
- replace `app.py` references with `models/inference/predictor.py`

## Testing
- `curl -s -X POST -H "Content-Type: application/json" -d '{"instances": [{"sst": 28.4, "turbidity": 3.1}]}' http://localhost:8080/v1/models/reefguard-model:predict`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f3963b4b88329b41cf3f7179175e9