### PR TITLE
Add pre-commit configuration and documentation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+  - repo: https://github.com/psf/black
+    rev: 23.10.1
+    hooks:
+      - id: black
+        language_version: python3
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+  - repo: https://github.com/PyCQA/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8

--- a/README.md
+++ b/README.md
@@ -11,17 +11,18 @@
 7. [Repository Structure](#repository-structure)
 8. [Local Development Quick‑Start](#local-development-quick-start)
 9. [Example Commands](#example-commands)
-10. [Infrastructure‑as‑Code](#infrastructure-as-code)
-11. [Data & Feature Management](#data--feature-management)
-12. [Automated Training & Tuning](#automated-training--tuning)
-13. [Model Registry & Promotion Workflow](#model-registry--promotion-workflow)
-14. [CI/CD Pipelines](#cicd-pipelines)
-15. [Model Serving & Deployment Strategies](#model-serving--deployment-strategies)
-16. [Monitoring & Observability](#monitoring--observability)
-17. [Cost Optimisation](#cost-optimisation)
-18. [Troubleshooting & FAQ](#troubleshooting--faq)
-19. [Stretch Goals](#stretch-goals)
-20. [References](#references)
+10. [Pre-commit Hooks](#pre-commit-hooks)
+11. [Infrastructure‑as‑Code](#infrastructure-as-code)
+12. [Data & Feature Management](#data--feature-management)
+13. [Automated Training & Tuning](#automated-training--tuning)
+14. [Model Registry & Promotion Workflow](#model-registry--promotion-workflow)
+15. [CI/CD Pipelines](#cicd-pipelines)
+16. [Model Serving & Deployment Strategies](#model-serving--deployment-strategies)
+17. [Monitoring & Observability](#monitoring--observability)
+18. [Cost Optimisation](#cost-optimisation)
+19. [Troubleshooting & FAQ](#troubleshooting--faq)
+20. [Stretch Goals](#stretch-goals)
+21. [References](#references)
 
 ---
 
@@ -190,6 +191,16 @@ python models/trainer/train.py --sample-data
 
 # Serve the latest model locally
 python models/inference/app.py --model-path models/artifacts/latest
+```
+
+## Pre-commit Hooks
+
+This project uses [pre-commit](https://pre-commit.com/) to run linters and formatters (black, flake8, isort).
+
+```bash
+pip install pre-commit
+pre-commit install
+pre-commit run --all-files
 ```
 
 ---


### PR DESCRIPTION
## Summary
- add `.pre-commit-config.yaml` with black, flake8, isort and basic sanity hooks
- document installing and running pre-commit in README

## Testing
- `pre-commit run --files README.md .pre-commit-config.yaml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f3965cf308329bb04592b2bc4bc61