### PR TITLE
Add unit tests for Predictor and ETL pipeline

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,42 @@
+import sys
+from pathlib import Path
+import types
+from torch import nn
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:  # pragma: no cover - sanity check
+    sys.path.insert(0, str(ROOT))
+
+# Provide a minimal stub for torchvision so ``models.trainer.model`` imports
+torchvision_stub = types.ModuleType("torchvision")
+models_stub = types.ModuleType("models")
+
+
+def _vit_b_16(weights=None):  # pragma: no cover - simple stub
+    model = nn.Identity()
+    model.heads = nn.Identity()
+    return model
+
+
+models_stub.vit_b_16 = _vit_b_16
+torchvision_stub.models = models_stub
+sys.modules.setdefault("torchvision", torchvision_stub)
+sys.modules.setdefault("torchvision.models", models_stub)
+
+# Minimal stub for kserve used by Predictor
+kserve_stub = types.ModuleType("kserve")
+
+
+class _KFModel:  # pragma: no cover - simple placeholder
+    def __init__(self, name: str):
+        self.name = name
+
+
+class _ModelServer:  # pragma: no cover - placeholder
+    def start(self, models):
+        return None
+
+
+kserve_stub.KFModel = _KFModel
+kserve_stub.ModelServer = _ModelServer
+sys.modules.setdefault("kserve", kserve_stub)

--- a/tests/test_etl_pipeline.py
+++ b/tests/test_etl_pipeline.py
@@ -1,0 +1,119 @@
+import importlib
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def fake_kfp(monkeypatch):
+    """Provide a minimal kfp stub so the pipeline module imports."""
+    kfp_module = types.ModuleType("kfp")
+    dsl_module = types.ModuleType("dsl")
+
+    def identity_decorator(*args, **kwargs):
+        def wrap(func):
+            return func
+        return wrap
+
+    dsl_module.component = identity_decorator
+    dsl_module.pipeline = identity_decorator
+    kfp_module.dsl = dsl_module
+    monkeypatch.setitem(sys.modules, "kfp", kfp_module)
+    monkeypatch.setitem(sys.modules, "kfp.dsl", dsl_module)
+
+
+def test_pull_sentinel2_uploads_to_s3(monkeypatch):
+    post_resp = MagicMock()
+    post_resp.json.return_value = {
+        "features": [{"assets": {"visual": {"href": "http://asset"}}}]
+    }
+    post_resp.raise_for_status.return_value = None
+    get_resp = MagicMock()
+    get_resp.content = b"data"
+
+    requests_mod = types.ModuleType("requests")
+    requests_mod.post = MagicMock(return_value=post_resp)
+    requests_mod.get = MagicMock(return_value=get_resp)
+    monkeypatch.setitem(sys.modules, "requests", requests_mod)
+
+    s3_client = MagicMock()
+    boto3_mod = types.ModuleType("boto3")
+    boto3_mod.client = MagicMock(return_value=s3_client)
+    monkeypatch.setitem(sys.modules, "boto3", boto3_mod)
+
+    etl = importlib.import_module("pipelines.kfp_v2.etl_pipeline")
+    uri = etl.pull_sentinel2(
+        lakefs_endpoint="http://lf",
+        bucket="bucket",
+        prefix="prefix",
+        region="1,2,3,4",
+        start_date="2023-01-01",
+        end_date="2023-01-02",
+    )
+
+    assert uri == "s3://bucket/prefix/sentinel2_visual.tif"
+    boto3_mod.client.assert_called_once_with("s3", endpoint_url="http://lf")
+    s3_client.put_object.assert_called_once_with(
+        Bucket="bucket", Key="prefix/sentinel2_visual.tif", Body=b"data"
+    )
+
+
+def test_pull_modis_sst(monkeypatch):
+    get_resp = MagicMock()
+    get_resp.content = b"sst"
+    requests_mod = types.ModuleType("requests")
+    requests_mod.get = MagicMock(return_value=get_resp)
+    monkeypatch.setitem(sys.modules, "requests", requests_mod)
+
+    s3_client = MagicMock()
+    boto3_mod = types.ModuleType("boto3")
+    boto3_mod.client = MagicMock(return_value=s3_client)
+    monkeypatch.setitem(sys.modules, "boto3", boto3_mod)
+
+    etl = importlib.import_module("pipelines.kfp_v2.etl_pipeline")
+    uri = etl.pull_modis_sst(
+        lakefs_endpoint="http://lf",
+        bucket="bucket",
+        prefix="prefix",
+        date="2023-001",
+    )
+
+    assert uri == "s3://bucket/prefix/modis_sst_2023-001.nc"
+    requests_mod.get.assert_called_once()
+    s3_client.put_object.assert_called_once_with(
+        Bucket="bucket", Key="prefix/modis_sst_2023-001.nc", Body=b"sst"
+    )
+
+
+def test_pull_qld_buoy(monkeypatch):
+    get_resp = MagicMock()
+    get_resp.content = b"{}"
+    get_resp.raise_for_status.return_value = None
+    requests_mod = types.ModuleType("requests")
+    requests_mod.get = MagicMock(return_value=get_resp)
+    monkeypatch.setitem(sys.modules, "requests", requests_mod)
+
+    s3_client = MagicMock()
+    boto3_mod = types.ModuleType("boto3")
+    boto3_mod.client = MagicMock(return_value=s3_client)
+    monkeypatch.setitem(sys.modules, "boto3", boto3_mod)
+
+    etl = importlib.import_module("pipelines.kfp_v2.etl_pipeline")
+    uri = etl.pull_qld_buoy(
+        lakefs_endpoint="http://lf",
+        bucket="bucket",
+        prefix="pref",
+        station_id="station-001",
+        api_key="KEY",
+    )
+
+    assert uri == "s3://bucket/pref/buoy_station-001.json"
+    requests_mod.get.assert_called_once()
+    args, kwargs = requests_mod.get.call_args
+    assert kwargs["headers"] == {"x-api-key": "KEY"}
+    assert kwargs["params"] == {"format": "json"}
+    s3_client.put_object.assert_called_once_with(
+        Bucket="bucket", Key="pref/buoy_station-001.json", Body=b"{}"
+    )

--- a/tests/test_predictor.py
+++ b/tests/test_predictor.py
@@ -1,0 +1,56 @@
+from unittest.mock import MagicMock
+
+import pandas as pd
+
+from models.inference.predictor import Predictor
+
+
+def test_load_uses_model_dir_and_configures_feast(monkeypatch, tmp_path):
+    """Ensure ``load`` pulls model from ``model_dir`` and sets up Feast."""
+    load_model = MagicMock()
+    monkeypatch.setattr(
+        "mlflow.pyfunc.load_model", load_model
+    )
+    fake_fs = MagicMock()
+    monkeypatch.setattr(
+        "models.inference.predictor.FeatureStore", fake_fs
+    )
+    monkeypatch.setenv("FEAST_REPO_PATH", "/feast_repo")
+
+    pred = Predictor("my-model", model_dir=str(tmp_path))
+    pred.load()
+
+    load_model.assert_called_once_with(str(tmp_path))
+    fake_fs.assert_called_once_with(repo_path="/feast_repo")
+    assert pred.model is load_model.return_value
+    assert pred.feature_store is fake_fs.return_value
+    assert pred.ready is True
+
+
+def test_predict_fetches_features_and_runs_model(monkeypatch):
+    """When only ``reef_id`` is provided, features are retrieved via Feast."""
+    pred = Predictor("model")
+    pred.model = MagicMock()
+    pred.model.predict.return_value = pd.Series([0.1, 0.2])
+
+    feature_store = MagicMock()
+    feature_store.get_online_features.return_value.to_df.return_value = pd.DataFrame(
+        {
+            "reef_id": [1, 2],
+            "sst_turbidity_view:sst_celsius": [10, 20],
+            "sst_turbidity_view:turbidity_ntu": [0.5, 0.7],
+        }
+    )
+    pred.feature_store = feature_store
+
+    request = {"instances": [{"reef_id": 1}, {"reef_id": 2}]}
+    result = pred.predict(request)
+
+    feature_store.get_online_features.assert_called_once()
+    args, kwargs = pred.model.predict.call_args
+    frame = args[0]
+    assert list(frame.columns) == [
+        "sst_turbidity_view:sst_celsius",
+        "sst_turbidity_view:turbidity_ntu",
+    ]
+    assert result == {"predictions": [0.1, 0.2]}


### PR DESCRIPTION
## Summary
- add coverage for Predictor model loading and Feast feature retrieval
- add tests for ETL pipeline components to mock remote downloads and S3 uploads

## Testing
- `pytest -q`
