### PR TITLE
feat: add trainer image and update pipeline

### DIFF
--- a/models/trainer/Dockerfile
+++ b/models/trainer/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY models/trainer models/trainer
+RUN pip install --no-cache-dir mlflow xgboost torch torchvision scikit-learn
+CMD ["python", "models/trainer/train.py"]

--- a/pipelines/kfp_v2/training_pipeline.py
+++ b/pipelines/kfp_v2/training_pipeline.py
@@ -97,7 +97,7 @@ def training_pipeline():
                                 "containers": [
                                     {
                                         "name": "training-container",
-                                        "image": "python:3.10",
+                                        "image": "ttl.sh/reefguard-trainer-1754218355:24h",
                                         "command": [
                                             "python",
                                             "models/trainer/train.py",


### PR DESCRIPTION
## Summary
- add Dockerfile for training environment with mlflow, xgboost, torch, torchvision, scikit-learn
- update Kubeflow training pipeline to use the trainer image instead of python:3.10

## Testing
- `pytest`

## Notes
- attempted to build/push `ttl.sh/reefguard-trainer-1754218355:24h` but podman build failed with `operation not permitted` while mounting `proc`

------
https://chatgpt.com/codex/tasks/task_e_688f3df5865083298f5032cbb103f120