### PR TITLE
docs: update inference script references

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ docker build -t reefguard/trainer models/trainer
 python models/trainer/train.py --sample-data
 
 # Serve the latest model locally
-python models/inference/app.py --model-path models/artifacts/latest
+python models/inference/predictor.py --model-path models/artifacts/latest
 ```
 
 ---

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,7 +57,7 @@ graph TD;
    ```
 4. Serve the latest model and query it.
    ```bash
-   python models/inference/app.py --model-path models/artifacts/latest &
+   python models/inference/predictor.py --model-path models/artifacts/latest &
    curl -X POST -H "Content-Type: application/json" \
      -d '{"features": {"sst": 28.4, "turbidity": 3.1}}' \
      http://localhost:8000/predict

--- a/docs/demo_script.md
+++ b/docs/demo_script.md
@@ -24,7 +24,7 @@ This walkthrough demonstrates an end-to-end run of the ReefGuard AI pipeline on 
    ```
 5. **Serve the model** – launch a simple inference service.
    ```bash
-   python models/inference/app.py --model-path models/artifacts/latest &
+   python models/inference/predictor.py --model-path models/artifacts/latest &
    ```
 6. **Query the endpoint** – send a test request and review the prediction.
    ```bash


### PR DESCRIPTION
## Summary
- fix documentation references to inference entrypoint
- point examples to `models/inference/predictor.py`

## Testing
- `pytest -q`
