### PR TITLE
Add pre-commit hooks and document usage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+  - repo: https://github.com/psf/black
+    rev: 24.1.1
+    hooks:
+      - id: black
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.0.0
+    hooks:
+      - id: flake8
+        additional_dependencies: [flake8-bugbear]

--- a/README.md
+++ b/README.md
@@ -162,10 +162,15 @@ reefguard-ai/
 
 ## Local Development Quick‑Start
 
+Install [pre-commit](https://pre-commit.com/) hooks to automatically format and
+lint code (Black, isort, Flake8) before each commit.
+
 ```bash
 # Clone & prep
 conda create -n reefguard python=3.11 -y && conda activate reefguard
 pip install -r requirements.txt -r requirements-dev.txt
+pre-commit install
+pre-commit run --all-files
 
 # Start MLflow & Feast locally
 mlflow server --backend-store-uri sqlite:///mlflow.db --default-artifact-root ./mlruns &


### PR DESCRIPTION
## Summary
- introduce `.pre-commit-config.yaml` with Black, isort, Flake8 and basic hygiene hooks
- document pre-commit installation and usage in the local development guide

## Testing
- `pre-commit run --files .pre-commit-config.yaml README.md`

------
https://chatgpt.com/codex/tasks/task_e_688f3df98ac483298ccedb88f2a302cc