### PR TITLE
Align training pipeline tests with new parameter names

### DIFF
--- a/tests/test_training_pipeline_spec.py
+++ b/tests/test_training_pipeline_spec.py
@@ -1,4 +1,5 @@
 import json
+
 from pipelines.kfp_v2 import training_pipeline
 
 
@@ -6,13 +7,25 @@ def test_katib_experiment_spec(monkeypatch):
     captured = {}
 
     def fake_katib_experiment(experiment_spec: str):
-        captured['spec'] = experiment_spec
+        captured["spec"] = experiment_spec
 
-    monkeypatch.setattr(training_pipeline, 'katib_experiment', fake_katib_experiment)
+    monkeypatch.setattr(
+        training_pipeline,
+        "katib_experiment",
+        fake_katib_experiment,
+    )
 
     training_pipeline.training_pipeline()
 
-    spec = json.loads(captured['spec'])
-    param_names = {p['name'] for p in spec['spec']['parameters']}
-    assert param_names == {'learningRate', 'maxDepth'}
-    assert spec['spec']['objective']['objectiveMetricName'] == 'accuracy'
+    spec = json.loads(captured["spec"])
+    param_names = {p["name"] for p in spec["spec"]["parameters"]}
+    assert param_names == {
+        "xgbLearningRate",
+        "xgbMaxDepth",
+        "xgbNEstimators",
+        "vitLr",
+        "vitEpochs",
+        "vitBatchSize",
+    }
+    objective_metric_name = spec["spec"]["objective"]["objectiveMetricName"]
+    assert objective_metric_name == "ensemble_accuracy"


### PR DESCRIPTION
## Summary
- update expected parameter names in training pipeline spec test
- verify objective metric is `ensemble_accuracy`

## Testing
- `pre-commit run --files tests/test_training_pipeline_spec.py`
- `pytest tests/test_training_pipeline_spec.py::test_katib_experiment_spec -q` *(fails: Artifacts must have both a schema_title and a schema_version)*