### PR TITLE
Reference stable trainer image

### DIFF
--- a/pipelines/kfp_v2/training_pipeline.py
+++ b/pipelines/kfp_v2/training_pipeline.py
@@ -138,7 +138,7 @@ def training_pipeline():
                                 "containers": [
                                     {
                                         "name": "training-container",
-                                        "image": "ttl.sh/reefguard-trainer-1754218355:24h",
+                                        "image": "gcr.io/reefguard/trainer:latest",
                                         "command": [
                                             "python",
                                             "models/trainer/train.py",

--- a/tests/test_training_pipeline_spec.py
+++ b/tests/test_training_pipeline_spec.py
@@ -14,5 +14,12 @@ def test_katib_experiment_spec(monkeypatch):
 
     spec = json.loads(captured['spec'])
     param_names = {p['name'] for p in spec['spec']['parameters']}
-    assert param_names == {'learningRate', 'maxDepth'}
-    assert spec['spec']['objective']['objectiveMetricName'] == 'accuracy'
+    assert param_names == {
+        'xgbLearningRate',
+        'xgbMaxDepth',
+        'xgbNEstimators',
+        'vitLr',
+        'vitEpochs',
+        'vitBatchSize',
+    }
+    assert spec['spec']['objective']['objectiveMetricName'] == 'ensemble_accuracy'


### PR DESCRIPTION
## Summary
- use persistent `gcr.io/reefguard/trainer:latest` image in Katib trial spec
- update Katib spec test for new hyperparameters and metric names

## Testing
- `pytest`
- :x: `docker build -t gcr.io/reefguard/trainer:latest -f models/trainer/Dockerfile .`
- :x: `docker push gcr.io/reefguard/trainer:latest`