### PR TITLE
docs: streamline local examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,8 +177,8 @@ mlflow server --backend-store-uri sqlite:///mlflow.db --default-artifact-root ./
 feast apply
 
 # Run a tiny sample pipeline
-python pipelines/kfp_v2/etl_pipeline.py --local-sample
-python models/trainer/train.py --sample-data
+python pipelines/kfp_v2/etl_pipeline.py
+python models/trainer/train.py
 ```
 
 ## Example Commands
@@ -191,10 +191,10 @@ pytest -q
 docker build -t reefguard/trainer models/trainer
 
 # Trigger a sample training run
-python models/trainer/train.py --sample-data
+python models/trainer/train.py
 
 # Serve the latest model locally
-python models/inference/predictor.py --model-path models/artifacts/latest
+python models/inference/predictor.py
 ```
 
 ---

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,14 +52,14 @@ graph TD;
    ```
 3. Ingest sample data and run a training job.
    ```bash
-   python pipelines/kfp_v2/etl_pipeline.py --local-sample
-   python models/trainer/train.py --sample-data
+   python pipelines/kfp_v2/etl_pipeline.py
+   python models/trainer/train.py
    ```
 4. Serve the latest model and query it.
    ```bash
-   python models/inference/predictor.py --model-path models/artifacts/latest &
+   python models/inference/predictor.py &
    curl -X POST -H "Content-Type: application/json" \
-     -d '{"features": {"sst": 28.4, "turbidity": 3.1}}' \
+     -d '{"instances": [{"sst_celsius": 28.4, "turbidity_ntu": 3.1}]}' \
      http://localhost:8000/predict
    ```
 

--- a/docs/demo_script.md
+++ b/docs/demo_script.md
@@ -16,20 +16,20 @@ This walkthrough demonstrates an end-to-end run of the ReefGuard AI pipeline on 
    ```
 3. **Ingest sample data** – run a lightweight ETL pipeline to pull a small dataset.
    ```bash
-   python pipelines/kfp_v2/etl_pipeline.py --local-sample
+   python pipelines/kfp_v2/etl_pipeline.py
    ```
 4. **Train a model** – execute the training script on the sample data.
    ```bash
-   python models/trainer/train.py --sample-data
+   python models/trainer/train.py
    ```
 5. **Serve the model** – launch a simple inference service.
    ```bash
-   python models/inference/predictor.py --model-path models/artifacts/latest &
+   python models/inference/predictor.py &
    ```
 6. **Query the endpoint** – send a test request and review the prediction.
    ```bash
    curl -X POST -H "Content-Type: application/json" \
-        -d '{"features": {"sst": 28.4, "turbidity": 3.1}}' \
+        -d '{"instances": [{"sst_celsius": 28.4, "turbidity_ntu": 3.1}]}' \
         http://localhost:8000/predict
    ```
 7. **Monitor** – import `docs/grafana_dash.json` into Grafana to view PSI drift, latency and heat-map panels.


### PR DESCRIPTION
## Summary
- remove unsupported CLI flags from local run examples
- send `instances` payload with `sst_celsius` and `turbidity_ntu`

## Testing
- `pre-commit run --files README.md docs/README.md docs/demo_script.md`
- `pytest -q` *(fails: TypeError: Artifacts must have both a schema_title and a schema_version, separated by `@`)*

