### PR TITLE
Rename sample drift features to SST and turbidity

### DIFF
--- a/data/current.csv
+++ b/data/current.csv
@@ -1,6 +1,6 @@
-feature_a,feature_b
-1,11
-2,21
-3,31
-4,41
-5,49
+sst_celsius,turbidity_ntu
+29,4
+30,5
+31,6
+32,7
+33,8

--- a/data/reference.csv
+++ b/data/reference.csv
@@ -1,6 +1,6 @@
-feature_a,feature_b
-1,10
-2,20
-3,30
-4,40
-5,50
+sst_celsius,turbidity_ntu
+27,3
+28,4
+29,5
+30,6
+31,7

--- a/evidently_tests.yaml
+++ b/evidently_tests.yaml
@@ -5,8 +5,8 @@ datasets:
     path: data/current.csv
 tests:
   - DataDriftTest:
-      column_name: feature_a
+      column_name: sst_celsius
       threshold: 0.1
   - DataDriftTest:
-      column_name: feature_b
+      column_name: turbidity_ntu
       threshold: 0.1


### PR DESCRIPTION
## Summary
- use `sst_celsius` and `turbidity_ntu` in Evidently drift tests
- regenerate sample `reference.csv` and `current.csv` with matching headers

## Testing
- `pre-commit run --files evidently_tests.yaml data/reference.csv data/current.csv`
- `pytest` *(fails: TypeError: Artifacts must have both a schema_title and a schema_version, separated by `@`)*
