### PR TITLE
feat: parameterize training pipeline image

### DIFF
--- a/pipelines/kfp_v2/README.md
+++ b/pipelines/kfp_v2/README.md
@@ -1,3 +1,5 @@
 # KFP v2 Pipelines
 
-Placeholder for Kubeflow Pipelines v2 definitions.
+This module houses our Kubeflow Pipelines v2 definitions. The primary entrypoint
+is `training_pipeline`, which now accepts an optional `image` parameter allowing
+the training container image to be overridden when constructing the pipeline.

--- a/pipelines/kfp_v2/training_pipeline.py
+++ b/pipelines/kfp_v2/training_pipeline.py
@@ -50,8 +50,16 @@ def katib_experiment(experiment_spec: str):
     name="reefguard-training-pipeline",
     description="Training pipeline with Katib Bayesian HPO",
 )
-def training_pipeline():
-    """Construct the pipeline that submits a Katib Bayesian optimization experiment."""
+def training_pipeline(
+    image: str = "gcr.io/reefguard/trainer:latest",
+):
+    """Construct the pipeline that submits a Katib Bayesian optimization experiment.
+
+    Parameters
+    ----------
+    image: str, optional
+        Container image to use for the Katib trial jobs.
+    """
     experiment_spec: Dict = {
         "apiVersion": "kubeflow.org/v1beta1",
         "kind": "Experiment",
@@ -138,7 +146,7 @@ def training_pipeline():
                                 "containers": [
                                     {
                                         "name": "training-container",
-                                        "image": "gcr.io/reefguard/trainer:latest",
+                                        "image": image,
                                         "command": [
                                             "python",
                                             "models/trainer/train.py",

--- a/tests/test_training_pipeline_spec.py
+++ b/tests/test_training_pipeline_spec.py
@@ -33,7 +33,7 @@ def test_katib_experiment_spec(monkeypatch):
         fake_katib_experiment,
     )
 
-    training_pipeline.training_pipeline()
+    training_pipeline.training_pipeline(image="test-image:latest")
 
     spec = json.loads(captured["spec"])
     param_names = {p["name"] for p in spec["spec"]["parameters"]}
@@ -47,3 +47,6 @@ def test_katib_experiment_spec(monkeypatch):
     }
     objective_metric_name = spec["spec"]["objective"]["objectiveMetricName"]
     assert objective_metric_name == "ensemble_accuracy"
+
+    container_image = spec["spec"]["trialTemplate"]["trialSpec"]["spec"]["template"]["spec"]["containers"][0]["image"]
+    assert container_image == "test-image:latest"


### PR DESCRIPTION
## Summary
- allow training pipeline to accept custom container image
- document and test image parameter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688f8f3ce8988329bb4ee34b5e863e25