### PR TITLE
Add predictor error handling tests

### DIFF
--- a/tests/test_predictor.py
+++ b/tests/test_predictor.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock
 
 import pandas as pd
+import pytest
 
 from models.inference.predictor import Predictor
 
@@ -54,3 +55,18 @@ def test_predict_fetches_features_and_runs_model(monkeypatch):
         "sst_turbidity_view:turbidity_ntu",
     ]
     assert result == {"predictions": [0.1, 0.2]}
+
+
+def test_predict_before_load_raises_error():
+    """Calling ``predict`` before ``load`` should error."""
+    pred = Predictor("model")
+    with pytest.raises(AttributeError):
+        pred.predict({"instances": [{"reef_id": 1}]})
+
+
+def test_predict_with_invalid_request_format_raises_error():
+    """Non-dict requests should raise an ``AttributeError``."""
+    pred = Predictor("model")
+    pred.model = MagicMock()
+    with pytest.raises(AttributeError):
+        pred.predict("not a dict")


### PR DESCRIPTION
## Summary
- extend predictor tests to cover predictions before loading model
- validate that invalid request formats raise AttributeError

## Testing
- `pytest tests/test_predictor.py -q`

