### PR TITLE
Allow custom training image in pipeline

### DIFF
--- a/pipelines/kfp_v2/training_pipeline.py
+++ b/pipelines/kfp_v2/training_pipeline.py
@@ -50,8 +50,16 @@ def katib_experiment(experiment_spec: str):
     name="reefguard-training-pipeline",
     description="Training pipeline with Katib Bayesian HPO",
 )
-def training_pipeline():
-    """Construct the pipeline that submits a Katib Bayesian optimization experiment."""
+def training_pipeline(image: str = "gcr.io/reefguard/trainer:latest"):
+    """Construct a Katib Bayesian optimization experiment.
+
+    Args:
+        image: Container image to use for the training job.
+    """
+    xgb_lr_param = "${trialParameters.xgbLearningRate}"
+    xgb_max_depth_param = "${trialParameters.xgbMaxDepth}"
+    xgb_n_estimators_param = "${trialParameters.xgbNEstimators}"
+
     experiment_spec: Dict = {
         "apiVersion": "kubeflow.org/v1beta1",
         "kind": "Experiment",
@@ -120,7 +128,12 @@ def training_pipeline():
                     },
                     {
                         "name": "vitEpochs",
-                        "description": "Training epochs for Vision Transformer",
+                        # fmt: off
+                        "description": (
+                            "Training epochs for Vision "
+                            "Transformer"
+                        ),
+                        # fmt: on
                         "reference": "vitEpochs",
                     },
                     {
@@ -138,18 +151,18 @@ def training_pipeline():
                                 "containers": [
                                     {
                                         "name": "training-container",
-                                        "image": "gcr.io/reefguard/trainer:latest",
+                                        "image": image,
                                         "command": [
                                             "python",
                                             "models/trainer/train.py",
                                         ],
                                         "args": [
                                             "--xgb-learning-rate",
-                                            "${trialParameters.xgbLearningRate}",
+                                            xgb_lr_param,
                                             "--xgb-max-depth",
-                                            "${trialParameters.xgbMaxDepth}",
+                                            xgb_max_depth_param,
                                             "--xgb-n-estimators",
-                                            "${trialParameters.xgbNEstimators}",
+                                            xgb_n_estimators_param,
                                             "--vit-lr",
                                             "${trialParameters.vitLr}",
                                             "--vit-epochs",


### PR DESCRIPTION
## Summary
- allow specifying custom image in training pipeline
- cover default and custom images in training pipeline spec test

## Testing
- `pre-commit run --files pipelines/kfp_v2/training_pipeline.py tests/test_training_pipeline_spec.py`
- `pytest tests/test_training_pipeline_spec.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f8f40902c8329bc89d446d794f084